### PR TITLE
Update Links to Docs

### DIFF
--- a/tutorials/12/steps/2/copy.html
+++ b/tutorials/12/steps/2/copy.html
@@ -16,4 +16,4 @@
 
 <p>In place of a number, you can use <code>fast</code> (200 milliseconds) or <code>slow</code> (600 milliseconds), just like jQuery.</p>
 
-<p>The parameters available to you depend on the transition. <a href='https://github.com/RactiveJS/Ractive/wiki/Plugins'>Visit the plugins page</a> to see which transitions are available and to create your own.</p>
+<p>The parameters available to you depend on the transition. <a href='http://docs.ractivejs.org/latest/plugins'>Visit the plugins page</a> to see which transitions are available and to create your own.</p>


### PR DESCRIPTION
Switch old github links to the new docs.ractivejs.org urls
