### PR TITLE
add missing `description` class

### DIFF
--- a/src/tutorials/09/steps/0/copy.html
+++ b/src/tutorials/09/steps/0/copy.html
@@ -5,7 +5,7 @@
 <pre class='prettyprint lang-js'>
 var item = "&lt;li class='{{ done ? \"done\" : \"pending\" }}'&gt;" +
              "&lt;input type='checkbox' checked='{{done}}'&gt;" +
-             "&lt;span on-tap='edit'&gt;" +
+             "&lt;span class='description' on-tap='edit'&gt;" +
                "{{description}}" +
 
                "{{#if editing}}" +

--- a/src/tutorials/09/steps/0/fixed/javascript.js
+++ b/src/tutorials/09/steps/0/fixed/javascript.js
@@ -1,6 +1,6 @@
 var item = "<li class='{{ done ? \"done\" : \"pending\" }}'>" +
              "<input type='checkbox' checked='{{done}}'>" +
-             "<span on-tap='edit'>" +
+             "<span class='description' on-tap='edit'>" +
                "{{description}}" +
 
                "{{#if editing}}" +

--- a/src/tutorials/09/steps/1/copy.html
+++ b/src/tutorials/09/steps/1/copy.html
@@ -6,7 +6,7 @@
 &lt;script id='item' type='text/ractive'&gt;
 &lt;li class='{{ done ? "done" : "pending" }}'&gt;
   &lt;input type='checkbox' checked='{{done}}'&gt;
-  &lt;span on-tap='edit'&gt;
+  &lt;span class='description' on-tap='edit'&gt;
     {{description}}
 
     {{#if editing}}
@@ -30,7 +30,7 @@
 &lt;!-- {{>item}} --&gt;
 &lt;li class='{{ done ? "done" : "pending" }}'&gt;
   &lt;input type='checkbox' checked='{{done}}'&gt;
-  &lt;span on-tap='edit'&gt;
+  &lt;span class='description' on-tap='edit'&gt;
     {{description}}
 
     {{#if editing}}

--- a/src/tutorials/09/steps/1/fixed/template.html
+++ b/src/tutorials/09/steps/1/fixed/template.html
@@ -11,7 +11,7 @@
 <!-- {{>item}} -->
 <li class='{{ done ? "done" : "pending" }}'>
   <input type='checkbox' checked='{{done}}'>
-  <span on-tap='edit'>
+  <span class='description' on-tap='edit'>
     {{description}}
 
     {{#if editing}}

--- a/src/tutorials/09/steps/1/javascript.js
+++ b/src/tutorials/09/steps/1/javascript.js
@@ -1,6 +1,6 @@
 var item = "<li class='{{ done ? \"done\" : \"pending\" }}'>" +
              "<input type='checkbox' checked='{{done}}'>" +
-             "<span on-tap='edit'>" +
+             "<span class='description' on-tap='edit'>" +
                "{{description}}" +
 
                "{{#if editing}}" +
@@ -98,8 +98,8 @@ var TodoList = Ractive.extend({
     enter: function ( node, fire ) {
       var keydownHandler = function ( event ) {
         var which = event.which || event.keyCode;
-        if ( which === 13 ) { 
-          fire({ node: node, original: event }); 
+        if ( which === 13 ) {
+          fire({ node: node, original: event });
         }
       };
 


### PR DESCRIPTION
Tutorial 10 has lost the `description` class after the item was moved to partial. The class is needed for line-through styling and thus UI degrades which may be confusing for readers.