### PR TITLE
use Inconsolata for monospace in tutorial copy

### DIFF
--- a/src/styles/copy.scss
+++ b/src/styles/copy.scss
@@ -15,7 +15,7 @@ kbd {
 	border-right-width: 2px;
 	border-bottom-width: 2px;
 	border-radius: 0.2em;
-	font-family: 'Source Code Pro';
+	font-family: Inconsolata, monospace;
 	font-size: 0.8em;
 	padding: 0.1em 0.3em;
 	white-space: pre;
@@ -53,7 +53,7 @@ kbd {
 #copy-block {
 	& > pre, aside > pre {
 		white-space: pre;
-		font-family: 'Source Code Pro', monospace;
+		font-family: Inconsolata, monospace;
 		font-size: 14px;
 		background-color: rgba(0,0,0,0.03);
 		display: block;
@@ -80,7 +80,7 @@ kbd {
 	}
 
 	code {
-		font-family: 'Source Code Pro';
+		font-family: Inconsolata, monospace;
 		background-color: rgba(0,0,0,0.03);
 		border: 1px solid rgba(0,0,0,0.08);
 		white-space: pre;


### PR DESCRIPTION
copy stylesheet declares 'Source Code Pro' to be used as monospace font in tutorial copy
but that font is not loaded (not even mentioned in `typograpy.scss`) and results in fallback font being used: http://take.ms/ahNVkn which is ugly

as the project already has Inconsolata for Codemirror I configured it to be used in copy as well